### PR TITLE
Ajout meilleur support MiniR3

### DIFF
--- a/core/class/sonoffdiy.class.php
+++ b/core/class/sonoffdiy.class.php
@@ -1182,6 +1182,9 @@ return [$indice, $derniertime];
 						$cmd->setEqLogic_id($this->getId());
 						$cmd->setName('Pulse On');
 						$cmd->setConfiguration('parameter', '5000');
+                        /* VB-) */
+                        // ----- Pour MiniR3 : stocke l'état à la fin du pulse (permet d'inverser le mode du pulse) 
+						$cmd->setConfiguration('etat_fin_pulse', 'off');                        
     					if ($R3)
     						$cmd->setConfiguration('request', 'pulses?command=on&outlet=0');
                         else
@@ -1617,11 +1620,12 @@ class sonoffdiyCmd extends cmd {
                 if (($parameter < 500) || ($parameter > 3599500) || ($parameter % 500 != 0)) {
                   $parameter = 5000;
                 }
+                $v_etat_fin_pulse = ($this->getConfiguration('etat_fin_pulse') == 'on' ? 'on' : 'off');
                 // ----- On doit indiquer les 4 outlets sinon la commande est refusée (contrairement à switches)
 				$pulses=[
 					[
                         "pulse" => $valeur,
-                        "switch" => "off",
+                        "switch" => $v_etat_fin_pulse,
                         "width" => $parameter,
                         "outlet" => intval($outlet)
 					],

--- a/core/class/sonoffdiy.class.php
+++ b/core/class/sonoffdiy.class.php
@@ -1661,6 +1661,15 @@ class sonoffdiyCmd extends cmd {
 						'data'    => $vide
 					);		
 			}
+
+/*VB-)*/
+            // ----- Dans le cas du miniR3, il est possible de ne pas avoir indiqué le deviceid, mais dans ce cas il ne faut pas envoyer
+            // le champ 'deviceid' du tout.
+            // Dans le cas du miniR2, on peut mettre n'importe quoi dans le champ deviceid ça ne change rien
+            if (($this->getEqLogic()->getConfiguration('device')=="miniR3") && ($device_id == '') && (isset($data['deviceid']))) {
+			  unset($data['deviceid']);
+            }
+
 			$payload = json_encode($data);
 		log::add('sonoffdiy', 'info', ' ');
 		log::add('sonoffdiy', 'info', '╔══════════════════════[Envoi '.$command.' sur '.$eqLogic->getName().']═════════════════════════════════════════════════════════');

--- a/core/class/sonoffdiy.class.php
+++ b/core/class/sonoffdiy.class.php
@@ -738,9 +738,12 @@ class sonoffdiy extends eqLogic {
 									if (is_array($_data_decoded['switches'])) {
 										foreach ($_data_decoded['switches'] as $switches){
 											if ($switches['outlet']=="0") self::sauvegardeCmdsInfoBis("switch", $switches['switch'], $eqLogic);// Pour MiniR3 et SPM
-											if ($switches['outlet']=="1") self::sauvegardeCmdsInfoBis("switch1", $switches['switch'], $eqLogic);// Pour SPM
-											if ($switches['outlet']=="2") self::sauvegardeCmdsInfoBis("switch2", $switches['switch'], $eqLogic);// Pour SPM
-											if ($switches['outlet']=="3") self::sauvegardeCmdsInfoBis("switch3", $switches['switch'], $eqLogic);// Pour SPM
+                                            // VB-) ----- Ne pas créer les commandes 1,2,3 pour les miniR3
+                                            if ($this->getConfiguration('device')!="miniR3") {
+        										if ($switches['outlet']=="1") self::sauvegardeCmdsInfoBis("switch1", $switches['switch'], $eqLogic);// Pour SPM
+    											if ($switches['outlet']=="2") self::sauvegardeCmdsInfoBis("switch2", $switches['switch'], $eqLogic);// Pour SPM
+    											if ($switches['outlet']=="3") self::sauvegardeCmdsInfoBis("switch3", $switches['switch'], $eqLogic);// Pour SPM
+                                            }
 										}
 									}
 								} 

--- a/core/class/sonoffdiy.class.php
+++ b/core/class/sonoffdiy.class.php
@@ -714,8 +714,22 @@ class sonoffdiy extends eqLogic {
 						$cestBonOnaTrouveleDevice=false;
 						foreach (eqLogic::byType('sonoffdiy') as $eqLogic){
 							//log::add('sonoffdiy_mDNS','info'," ***on test si ".$eqLogic->getConfiguration('device_id')." = ".$_ID);
-							if ((!($eqLogic->getConfiguration('device_id') == $_ID)) && (!($eqLogic->getConfiguration('esclave_id') == $_ID)) && ($_ID!='')) continue;
-							
+							//if ((!($eqLogic->getConfiguration('device_id') == $_ID)) && (!($eqLogic->getConfiguration('esclave_id') == $_ID)) && ($_ID!='')) continue;
+
+							/*VB-)*/
+                            // ----- S'il s'agit d'un miniR3 ou d'un miniR2 alors ils supportent de ne pas avoir de deviceID dans la 
+                            // configuration. Il faut donc ne prendre en compte que le eqLogic id de l'objet concerné. 
+                            // Sans impact sur la logic pour les autres objets
+                            //log::add('sonoffdiy','debug'," device type ".$this->getConfiguration('device'));
+                            //log::add('sonoffdiy','debug'," this ip ".$this->getId());
+                            //log::add('sonoffdiy','debug'," eqlogic ip ".$eqLogic->getId());
+                            if (   (($this->getConfiguration('device')=="miniR3") || ($this->getConfiguration('device')=="miniR2")) 
+                                && ($eqLogic->getId() != $this->getId())) continue;
+                                
+							if (   ($this->getConfiguration('device')!="miniR3") 
+                                && ($this->getConfiguration('device')!="miniR2") 
+                                && (!($eqLogic->getConfiguration('device_id') == $_ID)) && (!($eqLogic->getConfiguration('esclave_id') == $_ID)) && ($_ID!='')) continue;
+						
 							//log::add('sonoffdiy_mDNS','info'," ***ok trouvé ".$_ID);
 							$cestBonOnaTrouveleDevice=true;
 							foreach ($_data_decoded as $LogicalId => $value){

--- a/core/class/sonoffdiy.class.php
+++ b/core/class/sonoffdiy.class.php
@@ -777,7 +777,20 @@ class sonoffdiy extends eqLogic {
 											}
 										}
 									}
-								} 								
+								} 				
+/*VB-)*/
+                                // ----- Dans la cas du miniR2 l'id est renvoyé dans 'deviceid', il faut donc le reflecher vers le
+                                // nom de la commande "IDdetectee"
+                                elseif (($eqLogic->getConfiguration('device')=="miniR2") && ($LogicalId=='deviceid') && ($value!='')) {
+                                  self::sauvegardeCmdsInfoBis("IDdetectee", $value, $eqLogic);
+                                				
+                                }
+                                // ----- Dans la cas du miniR2 le rssi est renvoyé dans 'signalStrength', il faut donc le reflecher vers le
+                                // nom de la commande "rssi"
+                                elseif (($eqLogic->getConfiguration('device')=="miniR2") && ($LogicalId=='signalStrength') && ($value!='')) {
+                                  self::sauvegardeCmdsInfoBis("rssi", $value, $eqLogic);
+                                				
+                                }
 								elseif (!is_array($value)) self::sauvegardeCmdsInfoBis($LogicalId, $value, $eqLogic);
 								else log::add('sonoffdiy_mDNS','info'," Des données non enregistrées : ".json_encode($LogicalId)." = ".json_encode($value));
 							

--- a/core/class/sonoffdiy.class.php
+++ b/core/class/sonoffdiy.class.php
@@ -1193,7 +1193,7 @@ return [$indice, $derniertime];
     					$cmd = new sonoffdiyCmd();
     					$cmd->setType('info');
     					$cmd->setLogicalId('startup');
-      					$cmd->setSubType('binary');        
+      					$cmd->setSubType('string');        
     					$cmd->setEqLogic_id($this->getId());
     					$cmd->setName('Etat à la mise sous tension');
     					$cmd->setIsVisible(0);

--- a/desktop/js/sonoffdiy.js
+++ b/desktop/js/sonoffdiy.js
@@ -90,7 +90,10 @@ function addCmdToTable(_cmd)
    +   '<td>'
  //     +     '<span class="type" type="' + init(_cmd.type) + '">' + jeedom.cmd.availableType() + '</span>'
      +     '<input class="cmdAttr form-control type input-sm" data-l1key="type" value="info" type="hidden" disabled  />'
-     +     '<input class="cmdAttr form-control type input-sm" data-l1key="configuration" data-l2key="value" readonly  />'
+// VB-)
+//     +     '<input class="cmdAttr form-control type input-sm" data-l1key="configuration" data-l2key="value" readonly  />'
+     +     '<span class="cmdAttr" data-l1key="htmlstate"></span>'
+// VB-)
 //     +     '<input class="cmdAttr form-control type input-sm" data-l1key="value" disabled style="margin-bottom : 5px;" />'
  //   +   '</td>'
 //    +   '<td>'     

--- a/desktop/js/sonoffdiy.js
+++ b/desktop/js/sonoffdiy.js
@@ -181,7 +181,9 @@ function addCmdToTable(_cmd)
 		}
 		else if (init(_cmd.logicalId)=="PulseOn") {
 			tr +=     '<span style="font-size: 10px;">{{Pulse width}}:<input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="parameter" style="margin-top : 3px;"> ';
-			tr +=     '<span style="font-size: 10px;">{{Etat fin pulse}}:</span><input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="etat_fin_pulse" style="margin-top : 3px;"> ';
+            if ($('.eqLogicAttr[data-l1key=configuration][data-l2key=device]').value() == "miniR3") {
+    			tr +=     '<span style="font-size: 10px;">{{Etat fin pulse}}:</span><input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="etat_fin_pulse" style="margin-top : 3px;"> ';
+            }
 			//tr +=   '</td>';
 			//tr +=   '<td>';
 			tr +=     '';

--- a/desktop/js/sonoffdiy.js
+++ b/desktop/js/sonoffdiy.js
@@ -170,8 +170,18 @@ function addCmdToTable(_cmd)
 	tr +=   '</td>';
 	tr +=   '<td>';
 	
-		if ((init(_cmd.logicalId)=="PulseOff")||(init(_cmd.logicalId)=="PulseOn")) {
+// VB-)
+		if (init(_cmd.logicalId)=="PulseOff") {
+        // ----- Je pense que l'on peut aussi supprimer l'affichage du pulsewidth pour tous les devices. Mais je ne sais pas tester sur les autres donc je en touche pas
+        // l'idee serait de décharger l'affichage
 			tr +=     '<input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="parameter" style="margin-top : 3px;"> ';
+			//tr +=   '</td>';
+			//tr +=   '<td>';
+			tr +=     '';
+		}
+		else if (init(_cmd.logicalId)=="PulseOn") {
+			tr +=     '<span style="font-size: 10px;">{{Pulse width}}:<input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="parameter" style="margin-top : 3px;"> ';
+			tr +=     '<span style="font-size: 10px;">{{Etat fin pulse}}:</span><input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="etat_fin_pulse" style="margin-top : 3px;"> ';
 			//tr +=   '</td>';
 			//tr +=   '<td>';
 			tr +=     '';

--- a/desktop/js/sonoffdiy.js
+++ b/desktop/js/sonoffdiy.js
@@ -174,7 +174,7 @@ function addCmdToTable(_cmd)
 		if (init(_cmd.logicalId)=="PulseOff") {
         // ----- Je pense que l'on peut aussi supprimer l'affichage du pulsewidth pour tous les devices. Mais je ne sais pas tester sur les autres donc je en touche pas
         // l'idee serait de décharger l'affichage
-			tr +=     '<input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="parameter" style="margin-top : 3px;"> ';
+			//tr +=     '<input class="tooltips cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="parameter" style="margin-top : 3px;"> ';
 			//tr +=   '</td>';
 			//tr +=   '<td>';
 			tr +=     '';

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -92,8 +92,9 @@ function sonoffdiy_update() {
 		}
 
       } catch (Exception $e) {
-          log::add('sonoffdiy', 'error', $e->getMessage());
+          log::add('sonoffdiy', 'info', 'erreur creation commandes');
       }
+          log::add('sonoffdiy', 'info', 'Commandes OK');
 
     }
   }    

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -57,9 +57,6 @@ function sonoffdiy_update() {
     // ----- Update pour les miniR3
     if ($v_eq->getConfiguration('device')=="miniR3") {
       // ----- On créé la commande 'startup_action' si elle n'existe pas déjà
-      
-      try {
-      
     	$cmd = $v_eq->getCmd(null, 'startup_action');
     	if (!is_object($cmd)) {
     		$cmd = new sonoffdiyCmd();
@@ -90,11 +87,6 @@ function sonoffdiy_update() {
 			$cmd->setOrder(15); 
 			$cmd->save();
 		}
-
-      } catch (Exception $e) {
-          log::add('sonoffdiy', 'info', 'erreur creation commandes');
-      }
-          log::add('sonoffdiy', 'info', 'Commandes OK');
 
     }
   }    

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -88,6 +88,79 @@ function sonoffdiy_update() {
 			$cmd->save();
 		}
 
+		$cmd = $v_eq->getCmd(null, 'PulseOff');
+		if (!is_object($cmd)) {
+			$cmd = new sonoffdiyCmd();
+			$cmd->setType('action');
+			$cmd->setLogicalId('PulseOff');
+			$cmd->setSubType('other');
+			$cmd->setEqLogic_id($v_eq->getId());
+			$cmd->setName('Pulse Off');
+			$cmd->setConfiguration('request', 'pulses?command=off&outlet=0');
+			$cmd->setConfiguration('expliq', 'Désactive le mode Pulse');
+			$cmd->setDisplay('title_disable', 1);
+			$cmd->setOrder(6); 
+			$cmd->setIsVisible(0);
+			$cmd->save();
+		}
+
+		$cmd = $v_eq->getCmd(null, 'PulseOn');
+		if (!is_object($cmd)) {
+			$cmd = new sonoffdiyCmd();
+			$cmd->setType('action');
+			$cmd->setLogicalId('PulseOn');
+			$cmd->setSubType('message');
+			$cmd->setEqLogic_id($v_eq->getId());
+			$cmd->setName('Pulse On');
+			$cmd->setConfiguration('parameter', '5000');
+			$cmd->setConfiguration('etat_fin_pulse', 'off');                        
+			$cmd->setConfiguration('request', 'pulses?command=on&outlet=0');
+			$cmd->setConfiguration('expliq', 'Active le mode Pulse et fixe la tempo en ms (multiple de 500ms)');
+			$cmd->setDisplay('title_disable', 1);
+			$cmd->setOrder(7); 
+			$cmd->setIsVisible(0);
+			$cmd->save();
+		}
+
+		$cmd = $v_eq->getCmd(null, 'pulse');
+		if (!is_object($cmd)) {
+			$cmd = new sonoffdiyCmd();
+			$cmd->setType('info');
+			$cmd->setLogicalId('pulse');
+			$cmd->setSubType('binary');
+			$cmd->setEqLogic_id($v_eq->getId());
+			$cmd->setName('Etat de la fonction Pulse');
+			$cmd->setIsVisible(0);
+			$cmd->setOrder(10);
+			$cmd->save();
+		}
+				
+		$cmd = $v_eq->getCmd(null, 'pulseWidth');
+		if (!is_object($cmd)) {
+			$cmd = new sonoffdiyCmd();
+			$cmd->setType('info');
+			$cmd->setLogicalId('pulseWidth');
+			$cmd->setSubType('string');
+			$cmd->setEqLogic_id($v_eq->getId());
+			$cmd->setName('Tempo de la fonction Pulse');
+			$cmd->setIsVisible(0);
+			$cmd->setOrder(11);
+			$cmd->save();
+		}
+
+		$cmd = $v_eq->getCmd(null, 'pulseEndState');
+		if (!is_object($cmd)) {
+			$cmd = new sonoffdiyCmd();
+			$cmd->setType('info');
+			$cmd->setLogicalId('pulseEndState');
+			$cmd->setSubType('string');
+			$cmd->setEqLogic_id($v_eq->getId());
+			$cmd->setName('Etat à la fin du Pulse');
+			$cmd->setIsVisible(0);
+			$cmd->setOrder(12); 
+			$cmd->save();
+		}
+        
     }
   }    
 /*VB-)*/                        

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -57,6 +57,9 @@ function sonoffdiy_update() {
     // ----- Update pour les miniR3
     if ($v_eq->getConfiguration('device')=="miniR3") {
       // ----- On créé la commande 'startup_action' si elle n'existe pas déjà
+      
+      try {
+      
     	$cmd = $v_eq->getCmd(null, 'startup_action');
     	if (!is_object($cmd)) {
     		$cmd = new sonoffdiyCmd();
@@ -87,6 +90,11 @@ function sonoffdiy_update() {
 			$cmd->setOrder(15); 
 			$cmd->save();
 		}
+
+      } catch (Exception $e) {
+          log::add('sonoffdiy', 'error', $e->getMessage());
+      }
+
     }
   }    
 /*VB-)*/                        

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -69,7 +69,7 @@ function sonoffdiy_update() {
     		$cmd->setConfiguration('listValue', 'on|on;off|off;stay|stay');
     		$cmd->setConfiguration('expliq', "Définir l'état à la mise sous tension");
     		$cmd->setDisplay('title_disable', 1);
-    		$cmd->setOrder(4);
+    		$cmd->setOrder(5);
     		$cmd->setIsVisible(0);
     		$cmd->save();
     	}

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -56,7 +56,7 @@ function sonoffdiy_update() {
   foreach ($eqLogics as $v_eq) {
     // ----- Update pour les miniR3
     if ($v_eq->getConfiguration('device')=="miniR3") {
-      // ----- On créé la commande 'startup_action' si elle n'existe pas déjà
+      // ----- On crÃ©Ã© la commande 'startup_action' si elle n'existe pas dÃ©jÃ 
       
       try {
       
@@ -70,14 +70,14 @@ function sonoffdiy_update() {
     		$cmd->setName('Etat initial');					
     		$cmd->setConfiguration('request', 'startups?state=#select#&outlet=0');
     		$cmd->setConfiguration('listValue', 'on|on;off|off;stay|stay');
-    		$cmd->setConfiguration('expliq', "Définir l'état à la mise sous tension");
+    		$cmd->setConfiguration('expliq', "DÃ©finir l'Ã©tat Ã  la mise sous tension");
     		$cmd->setDisplay('title_disable', 1);
     		$cmd->setOrder(4);
     		$cmd->setIsVisible(0);
     		$cmd->save();
     	}
 
-      // ----- On créé la commande 'startup_action' si elle n'existe pas déjà
+      // ----- On crÃ©Ã© la commande 'startup_action' si elle n'existe pas dÃ©jÃ 
 		$cmd = $v_eq->getCmd(null, 'startup');
 		if (!is_object($cmd)) {
 			$cmd = new sonoffdiyCmd();
@@ -85,7 +85,7 @@ function sonoffdiy_update() {
 			$cmd->setLogicalId('startup');
    			$cmd->setSubType('string');
 			$cmd->setEqLogic_id($v_eq->getId());
-			$cmd->setName('Etat à la mise sous tension');
+			$cmd->setName('Etat Ã  la mise sous tension');
 			$cmd->setIsVisible(0);
 			$cmd->setOrder(15); 
 			$cmd->save();

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -49,6 +49,47 @@ function sonoffdiy_update() {
         $cron->save();
     }
     $cron->stop();
+    
+/*VB-)*/                        
+  // ----- Look for each equip
+  $eqLogics = eqLogic::byType('sonoffdiy');
+  foreach ($eqLogics as $v_eq) {
+    // ----- Update pour les miniR3
+    if ($v_eq->getConfiguration('device')=="miniR3") {
+      // ----- On créé la commande 'startup_action' si elle n'existe pas déjà
+    	$cmd = $v_eq->getCmd(null, 'startup_action');
+    	if (!is_object($cmd)) {
+    		$cmd = new sonoffdiyCmd();
+    		$cmd->setType('action');
+    		$cmd->setLogicalId('startup_action');
+    		$cmd->setSubType('select');
+    		$cmd->setEqLogic_id($v_eq->getId());
+    		$cmd->setName('Etat initial');					
+    		$cmd->setConfiguration('request', 'startups?state=#select#&outlet=0');
+    		$cmd->setConfiguration('listValue', 'on|on;off|off;stay|stay');
+    		$cmd->setConfiguration('expliq', "Définir l'état à la mise sous tension");
+    		$cmd->setDisplay('title_disable', 1);
+    		$cmd->setOrder(4);
+    		$cmd->setIsVisible(0);
+    		$cmd->save();
+    	}
+
+      // ----- On créé la commande 'startup_action' si elle n'existe pas déjà
+		$cmd = $v_eq->getCmd(null, 'startup');
+		if (!is_object($cmd)) {
+			$cmd = new sonoffdiyCmd();
+			$cmd->setType('info');
+			$cmd->setLogicalId('startup');
+   			$cmd->setSubType('string');
+			$cmd->setEqLogic_id($v_eq->getId());
+			$cmd->setName('Etat à la mise sous tension');
+			$cmd->setIsVisible(0);
+			$cmd->setOrder(15); 
+			$cmd->save();
+		}
+    }
+  }    
+/*VB-)*/                        
 }
 
 function sonoffdiy_remove() {


### PR DESCRIPTION

- Ajout de la mise à jour de l’état immédiatement après le changement de l’état on/off
- Ajout de la commande action “startup_action” pour le MiniR3 (comme les autres types), ajout de la commande info “startup” qui contient l’état en mode texte (on/off/stay)
- Ajout des commandes pour gérer le mode “pulse” pour le MiniR3
- Ajout de la commande info contenant l’état de retour après un pulse
- Support des MiniR2 et MiniR3 sans device_id configuré